### PR TITLE
Delay UI Initialization on Login

### DIFF
--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -76,20 +76,17 @@ local Defaults = {
 MS.Defaults = Defaults
 
 function MinimapStats:OnInitialize()
-    MS.db = LibStub("AceDB-3.0"):New("MinimapStatsDB", Defaults, true)
-    for key, value in pairs(Defaults) do
-        if MS.db.profile[key] == nil then
-            MS.db.profile[key] = value
-        end
-    end
+    MS.db = LibStub("AceDB-3.0"):New("MinimapStatsDB", Defaults)
 end
 
 function MinimapStats:OnEnable()
     MS:SetupSlashCommands()
-    MS:CreateTime()
-    MS:CreateSystemStats()
-    MS:CreateLocation()
-    MS:CreateCoordinates()
-    MS:CreateInstanceDifficulty()
-    MS:AssignTooltipScripts()
+    C_Timer.After(0, function()
+        MS:CreateTime()
+        MS:CreateSystemStats()
+        MS:CreateLocation()
+        MS:CreateCoordinates()
+        MS:CreateInstanceDifficulty()
+        MS:AssignTooltipScripts()
+    end)
 end

--- a/Core/Core.lua
+++ b/Core/Core.lua
@@ -79,14 +79,19 @@ function MinimapStats:OnInitialize()
     MS.db = LibStub("AceDB-3.0"):New("MinimapStatsDB", Defaults)
 end
 
-function MinimapStats:OnEnable()
+function MinimapStats:InitializeUI()
     MS:SetupSlashCommands()
+    MS:CreateTime()
+    MS:CreateSystemStats()
+    MS:CreateLocation()
+    MS:CreateCoordinates()
+    MS:CreateInstanceDifficulty()
+    MS:AssignTooltipScripts()
+end
+
+function MinimapStats:OnEnable()
+    local addon = self
     C_Timer.After(0, function()
-        MS:CreateTime()
-        MS:CreateSystemStats()
-        MS:CreateLocation()
-        MS:CreateCoordinates()
-        MS:CreateInstanceDifficulty()
-        MS:AssignTooltipScripts()
+        addon:InitializeUI()
     end)
 end


### PR DESCRIPTION
Delay initialization by one frame to ensure Blizzard UI is fully loaded. Fixes missing time, system stats, and location frames on login.

Also, removed the for loop as it did not seem necessary since AceDB automatically applies defaults.